### PR TITLE
Compose and sign transaction

### DIFF
--- a/LibWally.xcodeproj/project.pbxproj
+++ b/LibWally.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A232260122B94A6B00C3B79C /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A232260022B94A6B00C3B79C /* Transaction.swift */; };
+		A232260322B94A8400C3B79C /* TransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A232260222B94A8400C3B79C /* TransactionTests.swift */; };
 		A2330EF5229FF6A300A5F120 /* libwallycore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FEB0B872229C72A700459518 /* libwallycore.a */; };
 		FE120F55229C3B6900E7720C /* BIP39.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE120F54229C3B6900E7720C /* BIP39.swift */; };
 		FE39CDFA229DAAF400DD135E /* DataExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE39CDF9229DAAF400DD135E /* DataExtension.swift */; };
@@ -40,6 +42,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A232260022B94A6B00C3B79C /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
+		A232260222B94A8400C3B79C /* TransactionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionTests.swift; sourceTree = "<group>"; };
 		FE120F54229C3B6900E7720C /* BIP39.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BIP39.swift; sourceTree = "<group>"; };
 		FE39CDF5229D534100DD135E /* DemoPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = DemoPlayground.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		FE39CDF9229DAAF400DD135E /* DataExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtension.swift; sourceTree = "<group>"; };
@@ -51,7 +55,6 @@
 		FE9CD3BA229C397900345DFA /* LibWallyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LibWallyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE9CD3BF229C397900345DFA /* BIP39Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BIP39Tests.swift; sourceTree = "<group>"; };
 		FE9CD3C1229C397900345DFA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FEB0B467229C6B6C00459518 /* libwallycore.la */ = {isa = PBXFileReference; lastKnownFileType = text; name = libwallycore.la; path = "libwally-core/src/libwallycore.la"; sourceTree = "<group>"; };
 		FEB0B46B229C6BBB00459518 /* wally_script.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wally_script.h; sourceTree = "<group>"; };
 		FEB0B46C229C6BBB00459518 /* wally_elements.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wally_elements.h; sourceTree = "<group>"; };
 		FEB0B46D229C6BBB00459518 /* wally_crypto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wally_crypto.h; sourceTree = "<group>"; };
@@ -62,7 +65,6 @@
 		FEB0B472229C6BBB00459518 /* wally_bip32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wally_bip32.h; sourceTree = "<group>"; };
 		FEB0B473229C6BBB00459518 /* wally_bip38.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wally_bip38.h; sourceTree = "<group>"; };
 		FEB0B474229C6BBB00459518 /* wally_transaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wally_transaction.h; sourceTree = "<group>"; };
-		FEB0B870229C6EE400459518 /* libwallycore_la-bip39.lo */ = {isa = PBXFileReference; lastKnownFileType = text; name = "libwallycore_la-bip39.lo"; path = "libwally-core/src/libwallycore_la-bip39.lo"; sourceTree = "<group>"; };
 		FEB0B872229C72A700459518 /* libwallycore.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libwallycore.a; path = "libwally-core/src/.libs/libwallycore.a"; sourceTree = "<group>"; };
 		FEC79CE3229E7F3800D86E2E /* BIP32.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BIP32.swift; sourceTree = "<group>"; };
 		FEC79CE5229E807500D86E2E /* BIP32Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BIP32Tests.swift; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 				FEC79CE3229E7F3800D86E2E /* BIP32.swift */,
 				FE120F54229C3B6900E7720C /* BIP39.swift */,
 				FE8B80A322B3E5630041CC94 /* Script.swift */,
+				A232260022B94A6B00C3B79C /* Transaction.swift */,
 			);
 			path = LibWallySwift;
 			sourceTree = "<group>";
@@ -129,6 +132,7 @@
 				FEC79CE5229E807500D86E2E /* BIP32Tests.swift */,
 				FE9CD3BF229C397900345DFA /* BIP39Tests.swift */,
 				FE8B80A522B3E5760041CC94 /* ScriptTests.swift */,
+				A232260222B94A8400C3B79C /* TransactionTests.swift */,
 			);
 			path = LibWallyTests;
 			sourceTree = "<group>";
@@ -290,6 +294,7 @@
 				FE39CDFA229DAAF400DD135E /* DataExtension.swift in Sources */,
 				FE8B80A422B3E5630041CC94 /* Script.swift in Sources */,
 				FEC79CE4229E7F3800D86E2E /* BIP32.swift in Sources */,
+				A232260122B94A6B00C3B79C /* Transaction.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -299,6 +304,7 @@
 			files = (
 				FE8B80A622B3E5760041CC94 /* ScriptTests.swift in Sources */,
 				FEC79CE6229E807500D86E2E /* BIP32Tests.swift in Sources */,
+				A232260322B94A8400C3B79C /* TransactionTests.swift in Sources */,
 				FE9CD3C0229C397900345DFA /* BIP39Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LibWallySwift/Script.swift
+++ b/LibWallySwift/Script.swift
@@ -94,7 +94,7 @@ public struct ScriptSig : Equatable {
     // When used in a finalized transaction, scriptSig usually includes a signature:
     var signature: Signature?
     
-    init (_ type: ScriptSigType, _ scriptPubKey: ScriptPubKey) {
+    public init (_ type: ScriptSigType, _ scriptPubKey: ScriptPubKey) {
         var mutableScriptPubKey = scriptPubKey
         switch (type) {
         case .payToPubKeyHash(let pubKey):

--- a/LibWallySwift/Script.swift
+++ b/LibWallySwift/Script.swift
@@ -83,7 +83,7 @@ public struct ScriptPubKey : LosslessStringConvertible, Equatable {
 
 }
 
-public struct ScriptSig {
+public struct ScriptSig : Equatable {
     // When signing an input, its scriptSig is replaced by scriptPubKey of the output being spent
     let scriptPubKey: ScriptPubKey
     

--- a/LibWallySwift/Script.swift
+++ b/LibWallySwift/Script.swift
@@ -30,6 +30,7 @@ public enum ScriptSigPurpose {
     case signThisInput
     case signOtherInput
     case signed
+    case feeWorstCase
 }
 
 public struct ScriptPubKey : LosslessStringConvertible, Equatable {
@@ -110,6 +111,9 @@ public struct ScriptSig : Equatable {
             return self.scriptPubKey.bytes
         case .signOtherInput:
             return Data("")!
+        case .feeWorstCase:
+            let longestSignature = Data([UInt8].init(repeating: 0, count: Int(EC_SIGNATURE_DER_MAX_LOW_R_LEN)))
+            return Data([UInt8(longestSignature.count)]) + longestSignature + self.scriptPubKey.bytes
         case .signed:
             if let signature = self.signature {
                 return Data([UInt8(signature.count)]) + signature + self.scriptPubKey.bytes

--- a/LibWallySwift/Script.swift
+++ b/LibWallySwift/Script.swift
@@ -112,11 +112,13 @@ public struct ScriptSig : Equatable {
         case .signOtherInput:
             return Data("")!
         case .feeWorstCase:
-            let longestSignature = Data([UInt8].init(repeating: 0, count: Int(EC_SIGNATURE_DER_MAX_LOW_R_LEN)))
+            let longestSignature = Data([UInt8].init(repeating: 0, count: Int(EC_SIGNATURE_DER_MAX_LOW_R_LEN + 1)))
             return Data([UInt8(longestSignature.count)]) + longestSignature + self.scriptPubKey.bytes
         case .signed:
             if let signature = self.signature {
-                return Data([UInt8(signature.count)]) + signature + self.scriptPubKey.bytes
+                let lengthPush = Data([UInt8(signature.count + 1)]) // DER encoded signature + sighash byte
+                let sigHashByte = Data([UInt8(WALLY_SIGHASH_ALL)])
+                return lengthPush + signature + sigHashByte + Data([UInt8(self.pubKey.count)]) + self.pubKey
             } else {
                 return nil
             }

--- a/LibWallySwift/Script.swift
+++ b/LibWallySwift/Script.swift
@@ -27,7 +27,6 @@ public enum ScriptSigType {
 }
 
 public enum ScriptSigPurpose {
-    case signThisInput
     case signed
     case feeWorstCase
 }
@@ -84,30 +83,21 @@ public struct ScriptPubKey : LosslessStringConvertible, Equatable {
 }
 
 public struct ScriptSig : Equatable {
-    // When signing an input, its scriptSig is replaced by scriptPubKey of the output being spent
-    let scriptPubKey: ScriptPubKey
-    
     // In order to produce a (P2PKH) scriptSig a public key is needed:
     let pubKey: PubKey
 
     // When used in a finalized transaction, scriptSig usually includes a signature:
     var signature: Signature?
     
-    public init (_ type: ScriptSigType, _ scriptPubKey: ScriptPubKey) {
-        var mutableScriptPubKey = scriptPubKey
+    public init (_ type: ScriptSigType) {
         switch (type) {
         case .payToPubKeyHash(let pubKey):
-            precondition(mutableScriptPubKey.type == .payToPubKeyHash)
             self.pubKey = pubKey
         }
-        
-        self.scriptPubKey = scriptPubKey
     }
     
     public func render(_ purpose: ScriptSigPurpose) -> Data? {
         switch purpose {
-        case .signThisInput:
-            return self.scriptPubKey.bytes
         case .feeWorstCase:
              // DER encoded signature
             let dummySignature = Data([UInt8].init(repeating: 0, count: Int(EC_SIGNATURE_DER_MAX_LOW_R_LEN)))

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -48,19 +48,22 @@ public struct TxInput {
     }
     public var scriptPubKey: ScriptPubKey
     public var scriptSig: ScriptSig
+    public var amount: Satoshi
 
     public var witness: Data? {
         // TODO: obtain from wally_tx_input.witness
         return nil
     }
 
-    public init? (_ tx: Transaction, _ vout: UInt32, _ scriptSig: ScriptSig, _ scriptPubKey: ScriptPubKey) {
+    public init? (_ tx: Transaction, _ vout: UInt32, _ amount: Satoshi, _ scriptSig: ScriptSig, _ scriptPubKey: ScriptPubKey) {
         if tx.hash == nil {
             return nil
         }
 
         self.scriptSig = scriptSig
         self.scriptPubKey = scriptPubKey
+        
+        self.amount = amount
 
         let sequence: UInt32 = 0xFFFFFFFF
         
@@ -165,6 +168,19 @@ public struct Transaction {
         tx_output.pointee = output.wally_tx_output
         
         precondition(wally_tx_add_output(self.wally_tx, tx_output) == WALLY_OK)
+    }
+    
+    var totalIn: Satoshi? {
+        var tally: Satoshi = 0
+        if let inputs = self.inputs {
+            for input in inputs {
+                tally += input.amount
+            }
+        } else {
+            return nil
+        }
+        
+        return tally
     }
     
     var totalOut: Satoshi? {

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -53,17 +53,21 @@ struct TxInput {
         return nil
     }
 
-    init (_ tx: Transaction, _ vout: UInt32, _ scriptSig: ScriptSig) {
+    init? (_ tx: Transaction, _ vout: UInt32, _ scriptSig: ScriptSig) {
+        if tx.hash == nil {
+            return nil
+        }
+
         // We initialize self.wally_tx_input with an empty scriptSig, which is what's used when signing
         // for other inputs. We update it from self.scriptSig as needed during the signing process.
         self.scriptSig = scriptSig
 
         let sequence: UInt32 = 0
 
-        var tx_hash_bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: tx.hash.count)
-        let tx_hash_bytes_len = tx.hash.count
+        var tx_hash_bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: tx.hash!.count)
+        let tx_hash_bytes_len = tx.hash!.count
 
-        tx.hash.copyBytes(to: tx_hash_bytes, count: tx_hash_bytes_len)
+        tx.hash!.copyBytes(to: tx_hash_bytes, count: tx_hash_bytes_len)
 
         var output: UnsafeMutablePointer<wally_tx_input>?
         defer {
@@ -84,7 +88,7 @@ struct TxInput {
 }
 
 struct Transaction {
-    let hash: Data
+    var hash: Data? = nil
 
     init? (_ description: String) {
         if description.count == 64 { // Transaction hash

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -233,7 +233,9 @@ public struct Transaction {
             
             var tmp = privKeys[i].wally_ext_key.priv_key
             let privKey = [UInt8](UnsafeBufferPointer(start: &tmp.1, count: Int(EC_PRIVATE_KEY_LEN)))
-
+            // Ensure private key is valid
+            precondition(wally_ec_private_key_verify(privKey, Int(EC_PRIVATE_KEY_LEN)) == WALLY_OK)
+        
             precondition(wally_ec_sig_from_bytes(privKey, Int(EC_PRIVATE_KEY_LEN), message_bytes, Int(EC_MESSAGE_HASH_LEN), UInt32(EC_FLAG_ECDSA | EC_FLAG_GRIND_R), compact_sig_bytes, Int(EC_SIGNATURE_LEN)) == WALLY_OK)
             
             // Convert to low s form:

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -121,6 +121,26 @@ public struct Transaction {
         }
     }
     
+    public var description: String? {
+        if (self.wally_tx == nil) {
+            return nil
+        }
+        precondition(self.inputs != nil)
+        for input in self.inputs! {
+            if !input.signed {
+                return nil
+            }
+        }
+        var output: UnsafeMutablePointer<Int8>?
+        defer {
+            wally_free_string(output)
+        }
+        
+        precondition(wally_tx_to_hex(self.wally_tx, UInt32(WALLY_TX_FLAG_USE_WITNESS), &output) == WALLY_OK)
+        precondition(output != nil)
+        return String(cString: output!)
+    }
+    
     mutating func addInput (_ input: TxInput) {
         precondition(wally_tx_add_input(self.wally_tx, input.wally_tx_input) == WALLY_OK)
     }

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -237,6 +237,11 @@ public struct Transaction {
             precondition(wally_ec_private_key_verify(privKey, Int(EC_PRIVATE_KEY_LEN)) == WALLY_OK)
         
             precondition(wally_ec_sig_from_bytes(privKey, Int(EC_PRIVATE_KEY_LEN), message_bytes, Int(EC_MESSAGE_HASH_LEN), UInt32(EC_FLAG_ECDSA | EC_FLAG_GRIND_R), compact_sig_bytes, Int(EC_SIGNATURE_LEN)) == WALLY_OK)
+        
+            // Check that signature is valid and for the correct public key:
+            var tmpPub = privKeys[i].wally_ext_key.pub_key
+            let pubKey = [UInt8](UnsafeBufferPointer(start: &tmpPub.0, count: Int(EC_PUBLIC_KEY_LEN)))
+            precondition(wally_ec_sig_verify(pubKey, Int(EC_PUBLIC_KEY_LEN), message_bytes, Int(EC_MESSAGE_HASH_LEN), UInt32(EC_FLAG_ECDSA), compact_sig_bytes, Int(EC_SIGNATURE_LEN)) == WALLY_OK)
             
             // Convert to low s form:
             let sig_norm_bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: Int(EC_SIGNATURE_LEN))

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -92,7 +92,7 @@ public struct Transaction {
     public init? (_ description: String) {
         if description.count == 64 { // Transaction hash
             if let hash = Data(description) {
-                self.hash = hash
+                self.hash = Data(hash.reversed())
             } else {
                 return nil
             }

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -169,7 +169,7 @@ public struct Transaction {
         return value_out.pointee;
     }
     
-    var vbytes: Int? {
+    public var vbytes: Int? {
         if (self.wally_tx == nil) {
             return nil
         }

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -197,6 +197,15 @@ public struct Transaction {
         return value_out.pointee;
     }
     
+    var funded: Bool? {
+        if let totalOut = self.totalOut {
+            if let totalIn = self.totalIn {
+                return totalOut >= totalIn
+            }
+        }
+        return nil
+    }
+    
     public var vbytes: Int? {
         if (self.wally_tx == nil) {
             return nil

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -1,6 +1,6 @@
 //
 //  Transaction.swift
-//  Transaction 
+//  Transaction
 //
 //  Created by Sjors Provoost on 18/06/2019.
 //  Copyright © 2019 Blockchain. Distributed under the MIT software
@@ -8,9 +8,38 @@
 
 import Foundation
 
+typealias Satoshi = UInt64
+
+struct TxOutput {
+    let wally_tx_output: wally_tx_output
+    public var amount: Satoshi {
+        return self.wally_tx_output.satoshi
+    }
+    public let scriptPubKey: ScriptPubKey
+
+    init (_ scriptPubKey: ScriptPubKey, _ amount: Satoshi) {
+        self.scriptPubKey = scriptPubKey
+
+        var scriptpubkey_bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: scriptPubKey.bytes.count)
+        let scriptpubkey_bytes_len = scriptPubKey.bytes.count
+
+        scriptPubKey.bytes.copyBytes(to: scriptpubkey_bytes, count: scriptpubkey_bytes_len)
+
+        var output: UnsafeMutablePointer<wally_tx_output>?
+        defer {
+            if let wally_tx_output = output {
+                wally_tx_output.deallocate()
+            }
+        }
+        precondition(wally_tx_output_init_alloc(amount, scriptpubkey_bytes, scriptpubkey_bytes_len, &output) == WALLY_OK)
+        precondition(output != nil)
+        self.wally_tx_output = output!.pointee
+    }
+}
+
 struct Transaction {
     let hash: Data
-    
+
     init? (_ description: String) {
         if description.count == 64 { // Transaction hash
             if let hash = Data(description) {

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -8,16 +8,16 @@
 
 import Foundation
 
-typealias Satoshi = UInt64
+public typealias Satoshi = UInt64
 
-struct TxOutput {
+public struct TxOutput {
     let wally_tx_output: wally_tx_output
-    public var amount: Satoshi {
+    var amount: Satoshi {
         return self.wally_tx_output.satoshi
     }
-    public let scriptPubKey: ScriptPubKey
+    let scriptPubKey: ScriptPubKey
 
-    init (_ scriptPubKey: ScriptPubKey, _ amount: Satoshi) {
+    public init (_ scriptPubKey: ScriptPubKey, _ amount: Satoshi) {
         self.scriptPubKey = scriptPubKey
 
         var scriptpubkey_bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: scriptPubKey.bytes.count)
@@ -37,7 +37,7 @@ struct TxOutput {
     }
 }
 
-struct TxInput {
+public struct TxInput {
     var wally_tx_input: UnsafeMutablePointer<wally_tx_input>?
     let transaction: Transaction
     public var vout: UInt32 {
@@ -53,7 +53,7 @@ struct TxInput {
         return nil
     }
 
-    init? (_ tx: Transaction, _ vout: UInt32, _ scriptSig: ScriptSig) {
+    public init? (_ tx: Transaction, _ vout: UInt32, _ scriptSig: ScriptSig) {
         if tx.hash == nil {
             return nil
         }
@@ -81,15 +81,15 @@ struct TxInput {
     }
 }
 
-struct Transaction {
+public struct Transaction {
     var hash: Data? = nil
     
     var wally_tx: UnsafeMutablePointer<wally_tx>?
     
-    var inputs: [TxInput]? = nil
+    public var inputs: [TxInput]? = nil
     var outputs: [TxOutput]? = nil
 
-    init? (_ description: String) {
+    public init? (_ description: String) {
         if description.count == 64 { // Transaction hash
             if let hash = Data(description) {
                 self.hash = hash
@@ -102,7 +102,7 @@ struct Transaction {
 
     }
     
-    init (_ inputs: [TxInput], _ outputs: [TxOutput]) {
+    public init (_ inputs: [TxInput], _ outputs: [TxOutput]) {
         self.inputs = inputs
         self.outputs = outputs
         

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -235,6 +235,27 @@ public struct Transaction {
         return value_out.pointee;
     }
     
+    public var fee: Satoshi? {
+        if let totalOut = self.totalOut {
+            if let totalIn = self.totalIn {
+                if totalIn >= totalOut {
+                    return self.totalIn! - self.totalOut!
+                }
+            }
+        }
+        return nil
+    }
+    
+    public var feeRate: Float64? {
+        if let fee = self.fee {
+            if let vbytes = self.vbytes {
+                precondition(vbytes > 0)
+                return Float64(fee) / Float64(vbytes)
+            }
+        }
+        return nil
+    }
+    
     public mutating func sign (_ privKeys: [HDKey]) -> Bool {
         if self.wally_tx == nil {
             return false

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -200,7 +200,7 @@ public struct Transaction {
     var funded: Bool? {
         if let totalOut = self.totalOut {
             if let totalIn = self.totalIn {
-                return totalOut >= totalIn
+                return totalOut <= totalIn
             }
         }
         return nil

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -1,0 +1,27 @@
+//
+//  Transaction.swift
+//  Transaction 
+//
+//  Created by Sjors Provoost on 18/06/2019.
+//  Copyright © 2019 Blockchain. Distributed under the MIT software
+//  license, see the accompanying file LICENSE.md
+
+import Foundation
+
+struct Transaction {
+    let hash: Data
+    
+    init? (_ description: String) {
+        if description.count == 64 { // Transaction hash
+            if let hash = Data(description) {
+                self.hash = hash
+            } else {
+                return nil
+            }
+        } else { // Transaction hex
+            return nil
+        }
+
+    }
+
+}

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -146,6 +146,19 @@ struct Transaction {
         
         precondition(wally_tx_add_output(self.wally_tx, tx_output) == WALLY_OK)
     }
+    
+    var totalOut: Satoshi? {
+        if (self.wally_tx == nil) {
+            return nil
+        }
+        var value_out = UnsafeMutablePointer<UInt64>.allocate(capacity: 1)
+        defer {
+            value_out.deallocate()
+        }
+        
+        precondition(wally_tx_get_total_output_satoshi(self.wally_tx, value_out) == WALLY_OK)
+        
+        return value_out.pointee;
     }
 
 }

--- a/LibWallySwift/Transaction.swift
+++ b/LibWallySwift/Transaction.swift
@@ -62,7 +62,7 @@ public struct TxInput {
         // for other inputs. We update it from self.scriptSig as needed during the signing process.
         self.scriptSig = scriptSig
 
-        let sequence: UInt32 = 0
+        let sequence: UInt32 = 0xFFFFFFFF
         
         self.transaction = tx
 

--- a/LibWallyTests/ScriptTests.swift
+++ b/LibWallyTests/ScriptTests.swift
@@ -50,6 +50,9 @@ class ScriptTests: XCTestCase {
         XCTAssertEqual(scriptSig.render(.signed), nil)
 
         XCTAssertEqual(scriptSig.signature, nil)
+        
+        XCTAssertEqual(scriptSig.render(.feeWorstCase)?.count, 1 + Int(EC_SIGNATURE_DER_MAX_LOW_R_LEN) + scriptPubKey.bytes.count)
+        
         scriptSig.signature = Signature("01")!
         let signaturePush = Data("01")! + scriptSig.signature!
         XCTAssertEqual(scriptSig.render(.signed), signaturePush + scriptPubKey.bytes)

--- a/LibWallyTests/ScriptTests.swift
+++ b/LibWallyTests/ScriptTests.swift
@@ -56,4 +56,14 @@ class ScriptTests: XCTestCase {
         XCTAssertEqual(scriptSig.render(.signed)?.hexString, (signaturePush + pubKeyPush).hexString)
     }
 
+    func testWitnessP2WPKH() {
+        let pubKey = PubKey("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!
+        let witness = Witness(.payToWitnessPubKeyHash(pubKey))
+        XCTAssertEqual(witness.dummy, true)
+        XCTAssertEqual(witness.stack?.pointee.num_items, 2)
+        XCTAssertEqual(witness.scriptCode.hexString, "76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")
+        let signedWitness = Witness(.payToWitnessPubKeyHash(pubKey), Signature("01")!)
+        XCTAssertEqual(signedWitness.stack?.pointee.num_items, 2)
+        
+    }
 }

--- a/LibWallyTests/ScriptTests.swift
+++ b/LibWallyTests/ScriptTests.swift
@@ -38,4 +38,21 @@ class ScriptTests: XCTestCase {
         var scriptPubKey = ScriptPubKey("6a13636861726c6579206c6f766573206865696469")!
         XCTAssertEqual(scriptPubKey.type, .opReturn)
     }
+    
+    func testScriptSigP2PKH() {
+        let pubKey = PubKey("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!
+        let scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
+        var scriptSig = ScriptSig(.payToPubKeyHash(pubKey), scriptPubKey)
+        XCTAssertEqual(scriptSig.pubKey, pubKey)
+        XCTAssertEqual(scriptSig.scriptPubKey, scriptPubKey)
+        XCTAssertEqual(scriptSig.render(.signOtherInput), Data(""))
+        XCTAssertEqual(scriptSig.render(.signThisInput), scriptPubKey.bytes)
+        XCTAssertEqual(scriptSig.render(.signed), nil)
+
+        XCTAssertEqual(scriptSig.signature, nil)
+        scriptSig.signature = Signature("01")!
+        let signaturePush = Data("01")! + scriptSig.signature!
+        XCTAssertEqual(scriptSig.render(.signed), signaturePush + scriptPubKey.bytes)
+    }
+
 }

--- a/LibWallyTests/ScriptTests.swift
+++ b/LibWallyTests/ScriptTests.swift
@@ -41,11 +41,8 @@ class ScriptTests: XCTestCase {
     
     func testScriptSigP2PKH() {
         let pubKey = PubKey("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!
-        let scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
-        var scriptSig = ScriptSig(.payToPubKeyHash(pubKey), scriptPubKey)
+        var scriptSig = ScriptSig(.payToPubKeyHash(pubKey))
         XCTAssertEqual(scriptSig.pubKey, pubKey)
-        XCTAssertEqual(scriptSig.scriptPubKey, scriptPubKey)
-        XCTAssertEqual(scriptSig.render(.signThisInput), scriptPubKey.bytes)
         XCTAssertEqual(scriptSig.render(.signed), nil)
 
         XCTAssertEqual(scriptSig.signature, nil)

--- a/LibWallyTests/ScriptTests.swift
+++ b/LibWallyTests/ScriptTests.swift
@@ -45,13 +45,12 @@ class ScriptTests: XCTestCase {
         var scriptSig = ScriptSig(.payToPubKeyHash(pubKey), scriptPubKey)
         XCTAssertEqual(scriptSig.pubKey, pubKey)
         XCTAssertEqual(scriptSig.scriptPubKey, scriptPubKey)
-        XCTAssertEqual(scriptSig.render(.signOtherInput), Data(""))
         XCTAssertEqual(scriptSig.render(.signThisInput), scriptPubKey.bytes)
         XCTAssertEqual(scriptSig.render(.signed), nil)
 
         XCTAssertEqual(scriptSig.signature, nil)
         
-        XCTAssertEqual(scriptSig.render(.feeWorstCase)?.count, 2 + Int(EC_SIGNATURE_DER_MAX_LOW_R_LEN) + scriptPubKey.bytes.count)
+        XCTAssertEqual(scriptSig.render(.feeWorstCase)?.count, 2 + Int(EC_SIGNATURE_DER_MAX_LOW_R_LEN) + 1 + pubKey.count)
         
         scriptSig.signature = Signature("01")!
         let sigHashByte = Data("01")! // SIGHASH_ALL

--- a/LibWallyTests/ScriptTests.swift
+++ b/LibWallyTests/ScriptTests.swift
@@ -51,11 +51,13 @@ class ScriptTests: XCTestCase {
 
         XCTAssertEqual(scriptSig.signature, nil)
         
-        XCTAssertEqual(scriptSig.render(.feeWorstCase)?.count, 1 + Int(EC_SIGNATURE_DER_MAX_LOW_R_LEN) + scriptPubKey.bytes.count)
+        XCTAssertEqual(scriptSig.render(.feeWorstCase)?.count, 2 + Int(EC_SIGNATURE_DER_MAX_LOW_R_LEN) + scriptPubKey.bytes.count)
         
         scriptSig.signature = Signature("01")!
-        let signaturePush = Data("01")! + scriptSig.signature!
-        XCTAssertEqual(scriptSig.render(.signed), signaturePush + scriptPubKey.bytes)
+        let sigHashByte = Data("01")! // SIGHASH_ALL
+        let signaturePush = Data("02")! + scriptSig.signature! + sigHashByte
+        let pubKeyPush = Data([UInt8(pubKey.count)]) + pubKey
+        XCTAssertEqual(scriptSig.render(.signed)?.hexString, (signaturePush + pubKeyPush).hexString)
     }
 
 }

--- a/LibWallyTests/ScriptTests.swift
+++ b/LibWallyTests/ScriptTests.swift
@@ -42,7 +42,7 @@ class ScriptTests: XCTestCase {
     func testScriptSigP2PKH() {
         let pubKey = PubKey("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!
         var scriptSig = ScriptSig(.payToPubKeyHash(pubKey))
-        XCTAssertEqual(scriptSig.pubKey, pubKey)
+        XCTAssertEqual(scriptSig.type, ScriptSigType.payToPubKeyHash(pubKey))
         XCTAssertEqual(scriptSig.render(.signed), nil)
 
         XCTAssertEqual(scriptSig.signature, nil)

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -10,6 +10,8 @@ import XCTest
 @testable import LibWally
 
 class TransctionTests: XCTestCase {
+    let scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
+    let pubKey = PubKey("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!
 
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -23,13 +25,12 @@ class TransctionTests: XCTestCase {
         let hash = ("0000000000000000000000000000000000000000000000000000000000000000")
         let tx = Transaction(hash)
         XCTAssertNotNil(tx)
-        XCTAssertEqual(tx?.hash.hexString, hash)
+        XCTAssertEqual(tx?.hash?.hexString, hash)
 
         XCTAssertNil(Transaction("00")) // Wrong length
     }
 
     func testOutput() {
-        let scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
         let output = TxOutput(scriptPubKey, 1000)
         XCTAssertNotNil(output)
         XCTAssertEqual(output.amount, 1000)
@@ -39,18 +40,16 @@ class TransctionTests: XCTestCase {
     func testInput() {
         let tx = Transaction("0000000000000000000000000000000000000000000000000000000000000000")!
         let vout = UInt32(0)
-        let pubKey = PubKey("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!
-        let scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
         let scriptSig = ScriptSig(.payToPubKeyHash(pubKey), scriptPubKey)
 
         let input = TxInput(tx, vout, scriptSig)
         XCTAssertNotNil(input)
-        XCTAssertEqual(input.transaction.hash, tx.hash)
-        XCTAssertEqual(input.vout, 0)
-        XCTAssertEqual(input.sequence, 0)
-        XCTAssertEqual(input.scriptSig, scriptSig)
-        XCTAssertEqual(input.witness, nil)
-        XCTAssertEqual(input.signed, false)
+        XCTAssertEqual(input?.transaction.hash, tx.hash)
+        XCTAssertEqual(input?.vout, 0)
+        XCTAssertEqual(input?.sequence, 0)
+        XCTAssertEqual(input?.scriptSig, scriptSig)
+        XCTAssertEqual(input?.witness, nil)
+        XCTAssertEqual(input?.signed, false)
     }
 
 }

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import LibWally
 
-class TransctionTests: XCTestCase {
+class TransactionTests: XCTestCase {
     let scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
     let pubKey = PubKey("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!
 
@@ -50,6 +50,25 @@ class TransctionTests: XCTestCase {
         XCTAssertEqual(input?.scriptSig, scriptSig)
         XCTAssertEqual(input?.witness, nil)
         XCTAssertEqual(input?.signed, false)
+    }
+
+    func testComposeTransaction() {
+        // Input
+        let prevTx = Transaction("0000000000000000000000000000000000000000000000000000000000000000")!
+        let vout = UInt32(0)
+        let scriptSig = ScriptSig(.payToPubKeyHash(pubKey), scriptPubKey)
+        let txInput = TxInput(prevTx, vout, scriptSig)!
+
+        // Output:
+        let txOutput = TxOutput(scriptPubKey, 1000)
+
+        // Transaction
+        let tx = Transaction([txInput], [txOutput])
+        XCTAssertNil(tx.hash)
+        XCTAssertEqual(tx.wally_tx?.pointee.version, 1)
+        XCTAssertEqual(tx.wally_tx?.pointee.num_inputs, 1)
+        XCTAssertEqual(tx.wally_tx?.pointee.num_outputs, 1)
+    }
     }
 
 }

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -40,9 +40,9 @@ class TransactionTests: XCTestCase {
     func testInput() {
         let tx = Transaction("0000000000000000000000000000000000000000000000000000000000000000")!
         let vout = UInt32(0)
-        let scriptSig = ScriptSig(.payToPubKeyHash(pubKey), scriptPubKey)
+        let scriptSig = ScriptSig(.payToPubKeyHash(pubKey))
 
-        let input = TxInput(tx, vout, scriptSig)
+        let input = TxInput(tx, vout, scriptSig, scriptPubKey)
         XCTAssertNotNil(input)
         XCTAssertEqual(input?.transaction.hash, tx.hash)
         XCTAssertEqual(input?.vout, 0)
@@ -56,8 +56,8 @@ class TransactionTests: XCTestCase {
         // Input
         let prevTx = Transaction("0000000000000000000000000000000000000000000000000000000000000000")!
         let vout = UInt32(0)
-        let scriptSig = ScriptSig(.payToPubKeyHash(pubKey), scriptPubKey)
-        let txInput = TxInput(prevTx, vout, scriptSig)!
+        let scriptSig = ScriptSig(.payToPubKeyHash(pubKey))
+        let txInput = TxInput(prevTx, vout, scriptSig, scriptPubKey)!
 
         // Output:
         let txOutput = TxOutput(scriptPubKey, 1000)
@@ -84,8 +84,8 @@ class TransactionInstanceTests: XCTestCase {
         // Input (legacy P2PKH)
         let prevTx = Transaction("0000000000000000000000000000000000000000000000000000000000000000")!
         let vout = UInt32(0)
-        let scriptSig = ScriptSig(.payToPubKeyHash(pubKey), scriptPubKey)
-        let txInput = TxInput(prevTx, vout, scriptSig)!
+        let scriptSig = ScriptSig(.payToPubKeyHash(pubKey))
+        let txInput = TxInput(prevTx, vout, scriptSig, scriptPubKey)!
         
         // Output:
         let txOutput = TxOutput(scriptPubKey, 1000)

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -105,7 +105,7 @@ class TransactionInstanceTests: XCTestCase {
     }
     
     func testSize() {
-        XCTAssertEqual(tx?.vbytes, 182)
+        XCTAssertEqual(tx?.vbytes, 183)
         
         let tx2 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
         XCTAssertNil(tx2?.vbytes)

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -126,6 +126,10 @@ class TransactionInstanceTests: XCTestCase {
 
     }
     
+    func testFunded() {
+        XCTAssertEqual(tx?.funded, true)
+    }
+    
     func testSize() {
         XCTAssertEqual(tx?.vbytes, 192)
         

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -70,6 +70,12 @@ class TransactionTests: XCTestCase {
         XCTAssertEqual(tx.wally_tx?.pointee.num_outputs, 1)
     }
     
+    func testDeserialize() {
+        let hex = "01000000010000000000000000000000000000000000000000000000000000000000000000000000006a47304402203d274300310c06582d0186fc197106120c4838fa5d686fe3aa0478033c35b97802205379758b11b869ede2f5ab13a738493a93571268d66b2a875ae148625bd20578012103501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711cffffffff01e8030000000000001976a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac00000000"
+        let tx = Transaction(hex)
+        XCTAssertEqual(tx?.description, hex)
+    }
+    
 }
 
 class TransactionInstanceTests: XCTestCase {

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -73,10 +73,12 @@ class TransactionTests: XCTestCase {
 }
 
 class TransactionInstanceTests: XCTestCase {
-    // Pay to legacy P2PKH address
+    // From: legacy P2PKH address 1JQheacLPdM5ySCkrZkV66G2ApAXe1mqLj
+    // To: legacy P2PKH address 1JQheacLPdM5ySCkrZkV66G2ApAXe1mqLj
     let scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
     let pubKey = PubKey("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!
     var tx: Transaction? = nil
+    var hdKey: HDKey? = nil // private key for signing
     
     override func setUp() {
         // Input (legacy P2PKH)
@@ -90,6 +92,9 @@ class TransactionInstanceTests: XCTestCase {
         
         // Transaction
         tx = Transaction([txInput], [txOutput])
+        
+        // Corresponding private key
+       hdKey = HDKey("xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs")!
     }
     
     override func tearDown() {
@@ -110,6 +115,13 @@ class TransactionInstanceTests: XCTestCase {
         let tx2 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
         XCTAssertNil(tx2?.vbytes)
         
+    }
+    
+    func testSign() {
+        XCTAssertTrue(tx!.sign([hdKey!]))
+        XCTAssertEqual(tx!.inputs?[0].signed, true)
+        XCTAssertEqual(tx!.inputs?[0].scriptSig.signature?.hexString, "304402203d274300310c06582d0186fc197106120c4838fa5d686fe3aa0478033c35b97802205379758b11b869ede2f5ab13a738493a93571268d66b2a875ae148625bd20578")
+        XCTAssertEqual(tx!.description, "01000000010000000000000000000000000000000000000000000000000000000000000000000000006a47304402203d274300310c06582d0186fc197106120c4838fa5d686fe3aa0478033c35b97802205379758b11b869ede2f5ab13a738493a93571268d66b2a875ae148625bd20578012103501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711cffffffff01e8030000000000001976a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac00000000")
     }
 
 }

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -1,0 +1,31 @@
+//
+//  TransactionTests.swift
+//  TransactionTests 
+//
+//  Created by Sjors Provoost on 18/06/2019.
+//  Copyright © 2019 Blockchain. Distributed under the MIT software
+//  license, see the accompanying file LICENSE.md
+
+import XCTest
+@testable import LibWally
+
+class TransctionTests: XCTestCase {
+    
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testFromHash() {
+        let hash = ("0000000000000000000000000000000000000000000000000000000000000000")
+        let tx = Transaction(hash)
+        XCTAssertNotNil(tx)
+        XCTAssertEqual(tx?.hash.hexString, hash)
+        
+        XCTAssertNil(Transaction("00")) // Wrong length
+    }
+    
+}

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -69,6 +69,38 @@ class TransactionTests: XCTestCase {
         XCTAssertEqual(tx.wally_tx?.pointee.num_inputs, 1)
         XCTAssertEqual(tx.wally_tx?.pointee.num_outputs, 1)
     }
+    
+}
+
+class TransactionInstanceTests: XCTestCase {
+    let scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
+    let pubKey = PubKey("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!
+    var tx: Transaction? = nil
+    
+    override func setUp() {
+        // Input
+        let prevTx = Transaction("0000000000000000000000000000000000000000000000000000000000000000")!
+        let vout = UInt32(0)
+        let scriptSig = ScriptSig(.payToPubKeyHash(pubKey), scriptPubKey)
+        let txInput = TxInput(prevTx, vout, scriptSig)!
+        
+        // Output:
+        let txOutput = TxOutput(scriptPubKey, 1000)
+        
+        // Transaction
+        tx = Transaction([txInput], [txOutput])
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testTotalOut() {
+        XCTAssertEqual(tx?.totalOut, 1000)
+        
+        let tx2 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
+        XCTAssertNil(tx2?.totalOut)
+
     }
 
 }

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionTests.swift
-//  TransactionTests 
+//  TransactionTests
 //
 //  Created by Sjors Provoost on 18/06/2019.
 //  Copyright © 2019 Blockchain. Distributed under the MIT software
@@ -10,22 +10,29 @@ import XCTest
 @testable import LibWally
 
 class TransctionTests: XCTestCase {
-    
+
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-    
+
     func testFromHash() {
         let hash = ("0000000000000000000000000000000000000000000000000000000000000000")
         let tx = Transaction(hash)
         XCTAssertNotNil(tx)
         XCTAssertEqual(tx?.hash.hexString, hash)
-        
+
         XCTAssertNil(Transaction("00")) // Wrong length
     }
-    
+
+    func testOutput() {
+        let scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
+        let output = TxOutput(scriptPubKey, 1000)
+        XCTAssertNotNil(output)
+        XCTAssertEqual(output.amount, 1000)
+        XCTAssertEqual(output.scriptPubKey, scriptPubKey)
+    }
 }

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -40,9 +40,10 @@ class TransactionTests: XCTestCase {
     func testInput() {
         let tx = Transaction("0000000000000000000000000000000000000000000000000000000000000000")!
         let vout = UInt32(0)
+        let amount: Satoshi = 1000
         let scriptSig = ScriptSig(.payToPubKeyHash(pubKey))
 
-        let input = TxInput(tx, vout, scriptSig, scriptPubKey)
+        let input = TxInput(tx, vout, amount, scriptSig, scriptPubKey)
         XCTAssertNotNil(input)
         XCTAssertEqual(input?.transaction.hash, tx.hash)
         XCTAssertEqual(input?.vout, 0)
@@ -56,8 +57,9 @@ class TransactionTests: XCTestCase {
         // Input
         let prevTx = Transaction("0000000000000000000000000000000000000000000000000000000000000000")!
         let vout = UInt32(0)
+        let amount: Satoshi = 1000
         let scriptSig = ScriptSig(.payToPubKeyHash(pubKey))
-        let txInput = TxInput(prevTx, vout, scriptSig, scriptPubKey)!
+        let txInput = TxInput(prevTx, vout, amount, scriptSig, scriptPubKey)!
 
         // Output:
         let txOutput = TxOutput(scriptPubKey, 1000)
@@ -90,8 +92,9 @@ class TransactionInstanceTests: XCTestCase {
         // Input (legacy P2PKH)
         let prevTx = Transaction("0000000000000000000000000000000000000000000000000000000000000000")!
         let vout = UInt32(0)
+        let amount: Satoshi = 1000
         let scriptSig = ScriptSig(.payToPubKeyHash(pubKey))
-        let txInput = TxInput(prevTx, vout, scriptSig, scriptPubKey)!
+        let txInput = TxInput(prevTx, vout, amount, scriptSig, scriptPubKey)!
         
         // Output:
         let txOutput = TxOutput(scriptPubKey, 1000)
@@ -105,6 +108,14 @@ class TransactionInstanceTests: XCTestCase {
     
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testTotalIn() {
+        XCTAssertEqual(tx?.totalIn, 1000)
+        
+        let tx2 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
+        XCTAssertNil(tx2?.totalIn)
+        
     }
     
     func testTotalOut() {

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -35,4 +35,22 @@ class TransctionTests: XCTestCase {
         XCTAssertEqual(output.amount, 1000)
         XCTAssertEqual(output.scriptPubKey, scriptPubKey)
     }
+
+    func testInput() {
+        let tx = Transaction("0000000000000000000000000000000000000000000000000000000000000000")!
+        let vout = UInt32(0)
+        let pubKey = PubKey("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!
+        let scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
+        let scriptSig = ScriptSig(.payToPubKeyHash(pubKey), scriptPubKey)
+
+        let input = TxInput(tx, vout, scriptSig)
+        XCTAssertNotNil(input)
+        XCTAssertEqual(input.transaction.hash, tx.hash)
+        XCTAssertEqual(input.vout, 0)
+        XCTAssertEqual(input.sequence, 0)
+        XCTAssertEqual(input.scriptSig, scriptSig)
+        XCTAssertEqual(input.witness, nil)
+        XCTAssertEqual(input.signed, false)
+    }
+
 }

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -46,7 +46,7 @@ class TransactionTests: XCTestCase {
         XCTAssertNotNil(input)
         XCTAssertEqual(input?.transaction.hash, tx.hash)
         XCTAssertEqual(input?.vout, 0)
-        XCTAssertEqual(input?.sequence, 0)
+        XCTAssertEqual(input?.sequence, 0xFFFFFFFF)
         XCTAssertEqual(input?.scriptSig, scriptSig)
         XCTAssertEqual(input?.witness, nil)
         XCTAssertEqual(input?.signed, false)

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -43,13 +43,12 @@ class TransactionTests: XCTestCase {
         let amount: Satoshi = 1000
         let scriptSig = ScriptSig(.payToPubKeyHash(pubKey))
 
-        let input = TxInput(tx, vout, amount, scriptSig, scriptPubKey)
+        let input = TxInput(tx, vout, amount, scriptSig, nil, scriptPubKey)
         XCTAssertNotNil(input)
         XCTAssertEqual(input?.transaction.hash, tx.hash)
         XCTAssertEqual(input?.vout, 0)
         XCTAssertEqual(input?.sequence, 0xFFFFFFFF)
         XCTAssertEqual(input?.scriptSig, scriptSig)
-        XCTAssertEqual(input?.witness, nil)
         XCTAssertEqual(input?.signed, false)
     }
 
@@ -59,7 +58,7 @@ class TransactionTests: XCTestCase {
         let vout = UInt32(0)
         let amount: Satoshi = 1000
         let scriptSig = ScriptSig(.payToPubKeyHash(pubKey))
-        let txInput = TxInput(prevTx, vout, amount, scriptSig, scriptPubKey)!
+        let txInput = TxInput(prevTx, vout, amount, scriptSig, nil, scriptPubKey)!
 
         // Output:
         let txOutput = TxOutput(scriptPubKey, 1000)
@@ -81,26 +80,39 @@ class TransactionTests: XCTestCase {
 }
 
 class TransactionInstanceTests: XCTestCase {
+    let legacyInputBytes: Int = 192
+    let nativeSegWitInputBytes: Int = 113
+    
     // From: legacy P2PKH address 1JQheacLPdM5ySCkrZkV66G2ApAXe1mqLj
     // To: legacy P2PKH address 1JQheacLPdM5ySCkrZkV66G2ApAXe1mqLj
-    let scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
+    let scriptPubKey1 = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
     let pubKey = PubKey("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!
-    var tx: Transaction? = nil
+    var tx1: Transaction? = nil
+    var tx2: Transaction? = nil
     var hdKey: HDKey? = nil // private key for signing
     
     override func setUp() {
         // Input (legacy P2PKH)
         let prevTx = Transaction("0000000000000000000000000000000000000000000000000000000000000000")!
         let vout = UInt32(0)
-        let amount: Satoshi = 1192
+        let amount1: Satoshi = 1000 + Satoshi(legacyInputBytes)
         let scriptSig = ScriptSig(.payToPubKeyHash(pubKey))
-        let txInput = TxInput(prevTx, vout, amount, scriptSig, scriptPubKey)!
-        
+        let txInput1 = TxInput(prevTx, vout, amount1, scriptSig, nil, scriptPubKey1)!
+
+        // Input (native SegWit)
+        let witness = Witness(.payToWitnessPubKeyHash(pubKey))
+        let amount2: Satoshi = 1000 + Satoshi(nativeSegWitInputBytes)
+        let scriptPubKey2 = ScriptPubKey("0014bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe")!
+        let txInput2 = TxInput(prevTx, vout, amount2, nil, witness, scriptPubKey2)!
+
         // Output:
-        let txOutput = TxOutput(scriptPubKey, 1000)
+        let txOutput = TxOutput(scriptPubKey1, 1000)
         
-        // Transaction
-        tx = Transaction([txInput], [txOutput])
+        // Transaction spending legacy
+        tx1 = Transaction([txInput1], [txOutput])
+        
+        // Transaction spending native SegWit
+        tx2 = Transaction([txInput2], [txOutput])
         
         // Corresponding private key
        hdKey = HDKey("xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs")!
@@ -111,15 +123,16 @@ class TransactionInstanceTests: XCTestCase {
     }
     
     func testTotalIn() {
-        XCTAssertEqual(tx?.totalIn, 1192)
+        XCTAssertEqual(tx1?.totalIn, 1000 + Satoshi(legacyInputBytes))
+        XCTAssertEqual(tx2?.totalIn, 1000 + Satoshi(nativeSegWitInputBytes))
         
-        let tx2 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
-        XCTAssertNil(tx2?.totalIn)
+        let tx4 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
+        XCTAssertNil(tx4?.totalIn)
         
     }
     
     func testTotalOut() {
-        XCTAssertEqual(tx?.totalOut, 1000)
+        XCTAssertEqual(tx1?.totalOut, 1000)
         
         let tx2 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
         XCTAssertNil(tx2?.totalOut)
@@ -127,30 +140,42 @@ class TransactionInstanceTests: XCTestCase {
     }
     
     func testFunded() {
-        XCTAssertEqual(tx?.funded, true)
+        XCTAssertEqual(tx1?.funded, true)
     }
     
     func testSize() {
-        XCTAssertEqual(tx?.vbytes, 192)
+        XCTAssertEqual(tx1?.vbytes, legacyInputBytes)
+        XCTAssertEqual(tx2?.vbytes, nativeSegWitInputBytes)
+
         
-        let tx2 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
-        XCTAssertNil(tx2?.vbytes)
+        let tx4 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
+        XCTAssertNil(tx4?.vbytes)
         
     }
     
     func testFee() {
-        XCTAssertEqual(tx?.fee, 192)
+        XCTAssertEqual(tx1?.fee, Satoshi(legacyInputBytes))
     }
     
     func testFeeRate() {
-        XCTAssertEqual(tx?.feeRate, 1.0)
+        XCTAssertEqual(tx1?.feeRate, 1.0)
+        XCTAssertEqual(tx2?.feeRate, 1.0)
     }
     
     func testSign() {
-        XCTAssertTrue(tx!.sign([hdKey!]))
-        XCTAssertEqual(tx!.inputs?[0].signed, true)
-        XCTAssertEqual(tx!.inputs?[0].scriptSig.signature?.hexString, "304402203d274300310c06582d0186fc197106120c4838fa5d686fe3aa0478033c35b97802205379758b11b869ede2f5ab13a738493a93571268d66b2a875ae148625bd20578")
-        XCTAssertEqual(tx!.description, "01000000010000000000000000000000000000000000000000000000000000000000000000000000006a47304402203d274300310c06582d0186fc197106120c4838fa5d686fe3aa0478033c35b97802205379758b11b869ede2f5ab13a738493a93571268d66b2a875ae148625bd20578012103501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711cffffffff01e8030000000000001976a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac00000000")
+        XCTAssertTrue(tx1!.sign([hdKey!]))
+        XCTAssertEqual(tx1!.inputs?[0].signed, true)
+        XCTAssertEqual(tx1!.description, "01000000010000000000000000000000000000000000000000000000000000000000000000000000006a47304402203d274300310c06582d0186fc197106120c4838fa5d686fe3aa0478033c35b97802205379758b11b869ede2f5ab13a738493a93571268d66b2a875ae148625bd20578012103501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711cffffffff01e8030000000000001976a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac00000000")
+        
+        XCTAssertEqual(tx1!.vbytes, legacyInputBytes - 1)
+    }
+    
+    
+    func testSignNativeSegWit() {
+        XCTAssertTrue(tx2!.sign([hdKey!]))
+        XCTAssertEqual(tx2!.inputs?[0].signed, true)
+        XCTAssertEqual(tx2!.description, "0100000000010100000000000000000000000000000000000000000000000000000000000000000000000000ffffffff01e8030000000000001976a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac0247304402204094361e267c39fb942b3d30c6efb96de32ea0f81e87fc36c53e00de2c24555c022069f368ac9cacea21be7b5e7a7c1dad01aa244e437161d000408343a4d6f5da0e012103501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c00000000")
+        XCTAssertEqual(tx2!.vbytes, nativeSegWitInputBytes)
     }
 
 }

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -73,12 +73,13 @@ class TransactionTests: XCTestCase {
 }
 
 class TransactionInstanceTests: XCTestCase {
+    // Pay to legacy P2PKH address
     let scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
     let pubKey = PubKey("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!
     var tx: Transaction? = nil
     
     override func setUp() {
-        // Input
+        // Input (legacy P2PKH)
         let prevTx = Transaction("0000000000000000000000000000000000000000000000000000000000000000")!
         let vout = UInt32(0)
         let scriptSig = ScriptSig(.payToPubKeyHash(pubKey), scriptPubKey)
@@ -101,6 +102,14 @@ class TransactionInstanceTests: XCTestCase {
         let tx2 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
         XCTAssertNil(tx2?.totalOut)
 
+    }
+    
+    func testSize() {
+        XCTAssertEqual(tx?.vbytes, 182)
+        
+        let tx2 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
+        XCTAssertNil(tx2?.vbytes)
+        
     }
 
 }

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -110,7 +110,7 @@ class TransactionInstanceTests: XCTestCase {
     }
     
     func testSize() {
-        XCTAssertEqual(tx?.vbytes, 183)
+        XCTAssertEqual(tx?.vbytes, 192)
         
         let tx2 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
         XCTAssertNil(tx2?.vbytes)

--- a/LibWallyTests/TransactionTests.swift
+++ b/LibWallyTests/TransactionTests.swift
@@ -92,7 +92,7 @@ class TransactionInstanceTests: XCTestCase {
         // Input (legacy P2PKH)
         let prevTx = Transaction("0000000000000000000000000000000000000000000000000000000000000000")!
         let vout = UInt32(0)
-        let amount: Satoshi = 1000
+        let amount: Satoshi = 1192
         let scriptSig = ScriptSig(.payToPubKeyHash(pubKey))
         let txInput = TxInput(prevTx, vout, amount, scriptSig, scriptPubKey)!
         
@@ -111,7 +111,7 @@ class TransactionInstanceTests: XCTestCase {
     }
     
     func testTotalIn() {
-        XCTAssertEqual(tx?.totalIn, 1000)
+        XCTAssertEqual(tx?.totalIn, 1192)
         
         let tx2 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
         XCTAssertNil(tx2?.totalIn)
@@ -136,6 +136,14 @@ class TransactionInstanceTests: XCTestCase {
         let tx2 = Transaction("0000000000000000000000000000000000000000000000000000000000000000")
         XCTAssertNil(tx2?.vbytes)
         
+    }
+    
+    func testFee() {
+        XCTAssertEqual(tx?.fee, 192)
+    }
+    
+    func testFeeRate() {
+        XCTAssertEqual(tx?.feeRate, 1.0)
     }
     
     func testSign() {


### PR DESCRIPTION
Work in progress.

- [x] create TxOutput from scriptPubKey (obtained from address using #5) and amount
- [x] create TxInput from previous transaction hash, index and scriptPubKey
- [x] create `scriptSig` for P2PKH outputs, render depending on purpose (signing same / other input, as part of signed input, or to estimate fee)
- [x] compose unsigned transaction from [TxInput] and [TxOutput]
- [x] get fee estimate (vBytes)
- [x] sign inputs using private key (in HDKey)
- [x] (de)serialize signed transaction
- [x] handle native SegWit inputs (P2WPKH)
- [ ] handle wrapped SegWit inputs (P2SH-P2WPKH)
- [x] handle 64 byte transactions (see background in proposed soft-fork [forbid transactions 64 bytes or smaller](https://bitcoinops.org/en/newsletters/2019/03/05/)