### PR TITLE
BIP39 fixes

### DIFF
--- a/DemoPlayground.playground/Contents.swift
+++ b/DemoPlayground.playground/Contents.swift
@@ -7,8 +7,11 @@ let mnemonic = BIP39Mnemonic("abandon abandon abandon abandon abandon abandon ab
 mnemonic!.words.count
 mnemonic!.description
 
-
 // Initialize mnemonic from entropy:
+let bytes = [Int8](repeating: 0, count: 16)
+BIP39Entropy(Data(bytes: bytes, count: 16))
+
+// Or from hex string:
 BIP39Mnemonic(BIP39Entropy("00000000000000000000000000000000")!)
 
 // The seed hex is the starting point for BIP32 deriviation. It can take an optional BIP39 passphrase.

--- a/LibWally/BIP39.swift
+++ b/LibWally/BIP39.swift
@@ -10,7 +10,7 @@
 import Foundation
 import CLibWally
 
-let MAX_WORDS = 24 // Arbitrary, used only to determine array size in bip39_mnemonic_to_bytes
+let MAX_BYTES = 32 // Arbitrary, used only to determine array size in bip39_mnemonic_to_bytes
 
 public var BIP39Words: [String] = {
     // Implementation based on Blockstream Green Development Kit
@@ -78,8 +78,8 @@ public struct BIP39Mnemonic : LosslessStringConvertible, Equatable {
     }
     
     public init?(_ entropy: BIP39Entropy) {
-        precondition(entropy.data.count <= MAX_WORDS)
-        var bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: MAX_WORDS)
+        precondition(entropy.data.count <= MAX_BYTES)
+        var bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: MAX_BYTES)
         let bytes_len = entropy.data.count
         
         var output: UnsafeMutablePointer<Int8>?
@@ -109,7 +109,7 @@ public struct BIP39Mnemonic : LosslessStringConvertible, Equatable {
                 bytes_out.deallocate()
                 written.deallocate()
             }
-            precondition(bip39_mnemonic_to_bytes(nil, mnemonic, bytes_out, MAX_WORDS, written) == WALLY_OK)
+            precondition(bip39_mnemonic_to_bytes(nil, mnemonic, bytes_out, MAX_BYTES, written) == WALLY_OK)
             return BIP39Entropy(Data(bytes: bytes_out, count: written.pointee))
         }
     }
@@ -129,7 +129,7 @@ public struct BIP39Mnemonic : LosslessStringConvertible, Equatable {
 
     static func isValid(_ words: [String]) -> Bool {
         // Enforce maximum length
-        if (words.count > MAX_WORDS) { return false }
+        if (words.count > MAX_BYTES) { return false }
 
         // Check that each word appears in the BIP39 dictionary:
         if (!Set(words).subtracting(Set(BIP39Words)).isEmpty) {

--- a/LibWally/BIP39.swift
+++ b/LibWally/BIP39.swift
@@ -39,7 +39,7 @@ public struct BIP39Entropy : LosslessStringConvertible, Equatable {
         }
     }
     
-    init(_ data: Data) {
+    public init(_ data: Data) {
         self.data = data
     }
     

--- a/LibWallyTests/BIP39Tests.swift
+++ b/LibWallyTests/BIP39Tests.swift
@@ -12,6 +12,7 @@ import XCTest
 
 class BIP39Tests: XCTestCase {
     let validMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    let validMnemonic24 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"
 
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -41,6 +42,16 @@ class BIP39Tests: XCTestCase {
         XCTAssertNotNil(mnemonic)
         if (mnemonic != nil) {
             XCTAssertEqual(mnemonic!.words, validMnemonic.components(separatedBy: " "))
+        }
+    }
+    
+    func testInitializeMnemonicFromBytes() {
+        let bytes = [Int8](repeating: 0, count: 32)
+        let entropy = BIP39Entropy(Data(bytes: bytes, count: 32))
+        let mnemonic = BIP39Mnemonic(entropy)
+        XCTAssertNotNil(mnemonic)
+        if (mnemonic != nil) {
+            XCTAssertEqual(mnemonic!.words, validMnemonic24.components(separatedBy: " "))
         }
     }
     


### PR DESCRIPTION
Entropy was capped too short for 24 word mnemonics.

I also made it possible to initialize BIP39 entropy directly from bytes, rather than a hex string.