### PR TITLE
Make BIP39Entropy data var public

### DIFF
--- a/LibWally/BIP39.swift
+++ b/LibWally/BIP39.swift
@@ -29,7 +29,7 @@ public var BIP39Words: [String] = {
 }()
 
 public struct BIP39Entropy : LosslessStringConvertible, Equatable {
-    var data: Data
+    public var data: Data
     
     public init?(_ description: String) {
         if let data = Data(description) {


### PR DESCRIPTION
Useful for saving to the keychain.