### PR TITLE
Base58 support

### DIFF
--- a/LibWally.xcodeproj/project.pbxproj
+++ b/LibWally.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		A20C942522C6BC3900B0D206 /* libwallycore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A20C942422C6BC3900B0D206 /* libwallycore.a */; };
 		A232260122B94A6B00C3B79C /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A232260022B94A6B00C3B79C /* Transaction.swift */; };
 		A232260322B94A8400C3B79C /* TransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A232260222B94A8400C3B79C /* TransactionTests.swift */; };
+		A23509D72398F33E0045D3A5 /* DataExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23509D62398F33E0045D3A5 /* DataExtensionTests.swift */; };
 		A2F7489522C6D02B00EF11C8 /* LibWally.h in Headers */ = {isa = PBXBuildFile; fileRef = FE9CD3B4229C397900345DFA /* LibWally.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FE120F55229C3B6900E7720C /* BIP39.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE120F54229C3B6900E7720C /* BIP39.swift */; };
 		FE1A3C0622B395B300EDCB58 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1A3C0522B395B300EDCB58 /* Address.swift */; };
@@ -39,6 +40,7 @@
 		A20C942622C6BDB000B0D206 /* CLibWally */ = {isa = PBXFileReference; lastKnownFileType = folder; path = CLibWally; sourceTree = "<group>"; };
 		A232260022B94A6B00C3B79C /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
 		A232260222B94A8400C3B79C /* TransactionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionTests.swift; sourceTree = "<group>"; };
+		A23509D62398F33E0045D3A5 /* DataExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtensionTests.swift; sourceTree = "<group>"; };
 		FE120F54229C3B6900E7720C /* BIP39.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BIP39.swift; sourceTree = "<group>"; };
 		FE1A3C0522B395B300EDCB58 /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
 		FE39CDF5229D534100DD135E /* DemoPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = DemoPlayground.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -118,6 +120,7 @@
 			isa = PBXGroup;
 			children = (
 				FE9CD3C1229C397900345DFA /* Info.plist */,
+				A23509D62398F33E0045D3A5 /* DataExtensionTests.swift */,
 				FEC79CE5229E807500D86E2E /* BIP32Tests.swift */,
 				FE9CD3BF229C397900345DFA /* BIP39Tests.swift */,
 				FE8B80A122B397090041CC94 /* AddressTests.swift */,
@@ -259,6 +262,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FE8B80A222B397090041CC94 /* AddressTests.swift in Sources */,
+				A23509D72398F33E0045D3A5 /* DataExtensionTests.swift in Sources */,
 				FE8B80A622B3E5760041CC94 /* ScriptTests.swift in Sources */,
 				FEC79CE6229E807500D86E2E /* BIP32Tests.swift in Sources */,
 				A232260322B94A8400C3B79C /* TransactionTests.swift in Sources */,

--- a/LibWally/DataExtension.swift
+++ b/LibWally/DataExtension.swift
@@ -9,9 +9,7 @@
 import Foundation
 
 public extension Data {
-    var hexString: String {
-        return self.reduce("", { $0 + String(format: "%02x", $1) })
-    }
+
     init?(_ hexString: String) {
         let len = hexString.count / 2
         var data = Data(capacity: len)
@@ -26,5 +24,9 @@ public extension Data {
             }
         }
         self = data
+    }
+
+    var hexString: String {
+        return self.reduce("", { $0 + String(format: "%02x", $1) })
     }
 }

--- a/LibWallyTests/DataExtensionTests.swift
+++ b/LibWallyTests/DataExtensionTests.swift
@@ -1,0 +1,26 @@
+//
+//  DataExtensionTests.swift
+//  DataExtensionTests 
+//
+//  Created by Sjors Provoost on 05/12/2019.
+//  Copyright © 2019 Sjors Provoost. Distributed under the MIT software
+//  license, see the accompanying file LICENSE.md
+
+import XCTest
+
+class DataExtensionTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testHexString() {
+        let hexString = "01234567890abcde"
+        let data = Data(hexString)
+        XCTAssertEqual(data?.hexString, hexString)
+    }
+}

--- a/LibWallyTests/DataExtensionTests.swift
+++ b/LibWallyTests/DataExtensionTests.swift
@@ -23,4 +23,15 @@ class DataExtensionTests: XCTestCase {
         let data = Data(hexString)
         XCTAssertEqual(data?.hexString, hexString)
     }
+
+    func testToBase58() {
+        let data = Data("01234567890abcde")
+        XCTAssertEqual(data?.base58, "2FEDkTt23zPwhDwc")
+    }
+    
+    func testFromBase58() {
+        let base58 = "2FEDkTt23zPwhDwc"
+        let data = Data(base58: base58)
+        XCTAssertEqual(data?.hexString, "01234567890abcde")
+    }
 }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ a collection of useful primitives for cryptocurrency wallets.
 Supports a minimal set of features based on v0.7.5. See also [original docs](https://wally.readthedocs.io/en/release_0.7.5).
 
 - [ ] Core Functions
+  - [x] base58 encode / decode
 - [ ] Crypto Functions
   - [x] sign ECDSA, convert to DER
 - [ ] Address Functions


### PR DESCRIPTION
Uses `wally_base58_to_bytes` and `wally_base58_from_bytes` to convert base58 strings back and forth to `Data`.

```
Data("01234567890abcde") -> "2FEDkTt23zPwhDwc")
Data(base58: "2FEDkTt23zPwhDwc")?.hexString -> "01234567890abcde"
```