### PR TITLE
Multisig address derivation

### DIFF
--- a/LibWally/Script.swift
+++ b/LibWally/Script.swift
@@ -39,9 +39,9 @@ public enum WitnessType {
 
 public struct ScriptPubKey : LosslessStringConvertible, Equatable {
     var bytes: Data
-
-    public lazy var type: ScriptType? = {
-        var bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: self.bytes.count)
+    
+    public var type: ScriptType? {
+        let bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: self.bytes.count)
         let bytes_len = self.bytes.count
         let output = UnsafeMutablePointer<Int>.allocate(capacity: 1)
 
@@ -66,7 +66,7 @@ public struct ScriptPubKey : LosslessStringConvertible, Equatable {
             precondition(output.pointee == WALLY_SCRIPT_TYPE_UNKNOWN)
             return nil
         }
-    }()
+    }
 
     public init?(_ description: String) {
         if let data = Data(description) {

--- a/LibWally/Script.swift
+++ b/LibWally/Script.swift
@@ -106,6 +106,21 @@ public struct ScriptPubKey : LosslessStringConvertible, Equatable {
         self.bytes = bytes
     }
 
+    public var witnessProgram: Data {
+        let bytes_len = self.bytes.count
+        let bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: bytes_len)
+        self.bytes.copyBytes(to: bytes, count: bytes_len)
+        let script_bytes_len = 34 // 00 20 HASH256
+        var script_bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: script_bytes_len)
+        var written = UnsafeMutablePointer<Int>.allocate(capacity: 1)
+        defer {
+            script_bytes.deallocate()
+            written.deallocate()
+        }
+        precondition(wally_witness_program_from_bytes(bytes, bytes_len, UInt32(WALLY_SCRIPT_SHA256), script_bytes, script_bytes_len, written) == WALLY_OK)
+        precondition(written.pointee == script_bytes_len)
+        return Data(bytes: script_bytes, count: written.pointee)
+    }
 
 }
 

--- a/LibWallyTests/ScriptTests.swift
+++ b/LibWallyTests/ScriptTests.swift
@@ -67,4 +67,11 @@ class ScriptTests: XCTestCase {
         XCTAssertEqual(signedWitness.stack?.pointee.num_items, 2)
 
     }
+    
+    func testMultisig() {
+        let pubKey1 = PubKey(Data("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!, .mainnet)! // [3442193e/0'/1]
+        let pubKey2 = PubKey(Data("022e3d55c64908832291348d1faa74bff4ae1047e9777a28b26b064e410a554737")!, .mainnet)! // [bd16bee5/0'/1]
+        let multisig = ScriptPubKey(multisig: [pubKey1, pubKey2], threshold: 2)
+        XCTAssertEqual(multisig.type, .multiSig)
+    }
 }

--- a/LibWallyTests/ScriptTests.swift
+++ b/LibWallyTests/ScriptTests.swift
@@ -21,22 +21,22 @@ class ScriptTests: XCTestCase {
     }
 
     func testDetectScriptPubKeyTypeP2PKH() {
-        var scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
+        let scriptPubKey = ScriptPubKey("76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac")!
         XCTAssertEqual(scriptPubKey.type, .payToPubKeyHash)
     }
 
     func testDetectScriptPubKeyTypeP2SH() {
-        var scriptPubKey = ScriptPubKey("a91486cc442a97817c245ce90ed0d31d6dbcde3841f987")!
+        let scriptPubKey = ScriptPubKey("a91486cc442a97817c245ce90ed0d31d6dbcde3841f987")!
         XCTAssertEqual(scriptPubKey.type, .payToScriptHash)
     }
 
     func testDetectScriptPubKeyTypeNativeSegWit() {
-        var scriptPubKey = ScriptPubKey("0014bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe")!
+        let scriptPubKey = ScriptPubKey("0014bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe")!
         XCTAssertEqual(scriptPubKey.type, .payToWitnessPubKeyHash)
     }
 
     func testDetectScriptPubKeyTypeOpReturn() {
-        var scriptPubKey = ScriptPubKey("6a13636861726c6579206c6f766573206865696469")!
+        let scriptPubKey = ScriptPubKey("6a13636861726c6579206c6f766573206865696469")!
         XCTAssertEqual(scriptPubKey.type, .opReturn)
     }
 

--- a/LibWallyTests/ScriptTests.swift
+++ b/LibWallyTests/ScriptTests.swift
@@ -67,11 +67,16 @@ class ScriptTests: XCTestCase {
         XCTAssertEqual(signedWitness.stack?.pointee.num_items, 2)
 
     }
-    
+
     func testMultisig() {
         let pubKey1 = PubKey(Data("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c")!, .mainnet)! // [3442193e/0'/1]
         let pubKey2 = PubKey(Data("022e3d55c64908832291348d1faa74bff4ae1047e9777a28b26b064e410a554737")!, .mainnet)! // [bd16bee5/0'/1]
         let multisig = ScriptPubKey(multisig: [pubKey1, pubKey2], threshold: 2)
         XCTAssertEqual(multisig.type, .multiSig)
+        XCTAssertEqual(multisig.bytes.hexString, "5221022e3d55c64908832291348d1faa74bff4ae1047e9777a28b26b064e410a5547372103501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c52ae")
+        XCTAssertEqual(multisig.witnessProgram.hexString, "0020ce8c526b7a6c9491ed33861f4492299c86ffa8567a75286535f317ddede3062a")
+
+        let address = Address(multisig, .mainnet)
+        XCTAssertEqual(address?.address, "bc1qe6x9y6m6dj2frmfnsc05fy3fnjr0l2zk0f6jsef47vtamm0rqc4qnfnxm0")
     }
 }


### PR DESCRIPTION
~Depends on #18 (because it introduces Swift 5.1 behavior when handling an optional enum)~

This adds the ability to generate a multisig address for a set of public keys ([HDKey]) and a threshold (e.g. 2 of 2).

It adds a `scriptPubKey` initializer to `Address`, which uses a new `witnessProgram` property on `ScriptPubKey`. This should be expanded to handle different types of `ScriptType` (maybe in a different PR). See also #7.

It adds a `multisig` initializer to `ScriptPubKey` which uses `wally_scriptpubkey_multisig_from_bytes` internally: https://wally.readthedocs.io/en/release_0.7.5/script/#c.wally_scriptpubkey_multisig_from_bytes