### PR TITLE
Bump Travis OSX and Swift to 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: swift
 xcode_project: LibWally.xcodeproj
 xcode_scheme: LibWally
 xcode_destination: platform=iOS Simulator,OS=12.2,name=iPhone Xʀ
-osx_image: xcode10.2
+osx_image: xcode11.2
 
 cache: ccache
 
 install:
+  - swift --version
   - brew install gnu-sed ccache
   - export PATH="/usr/local/opt/ccache/libexec:$PATH"
   - ./build-libwally.sh -s


### PR DESCRIPTION
This bumps Swift from 5.0 to 5.1

Also prints the Swift version.