### PR TITLE
Data extension: base58 initializer returns nil with invalid character

### DIFF
--- a/LibWally/DataExtension.swift
+++ b/LibWally/DataExtension.swift
@@ -35,7 +35,9 @@ public extension Data {
             bytes_out.deallocate()
             written.deallocate()
         }
-        precondition(wally_base58_to_bytes(strBase58, UInt32(BASE58_FLAG_CHECKSUM), bytes_out, len, written) == WALLY_OK)
+        guard wally_base58_to_bytes(strBase58, UInt32(BASE58_FLAG_CHECKSUM), bytes_out, len, written) == WALLY_OK else {
+            return nil
+        }
         self = Data(bytes: bytes_out, count: written.pointee)
     }
 

--- a/LibWallyTests/DataExtensionTests.swift
+++ b/LibWallyTests/DataExtensionTests.swift
@@ -34,4 +34,9 @@ class DataExtensionTests: XCTestCase {
         let data = Data(base58: base58)
         XCTAssertEqual(data?.hexString, "01234567890abcde")
     }
+    
+    func testInvalidCharacter() {
+        let base58 = "💩"
+        XCTAssertNil(Data(base58: base58))
+    }
 }


### PR DESCRIPTION
Previously it would hit the precondition.