### PR TITLE
Script multisig: check threshold > 0

### DIFF
--- a/LibWally/Script.swift
+++ b/LibWally/Script.swift
@@ -77,6 +77,7 @@ public struct ScriptPubKey : LosslessStringConvertible, Equatable {
     }
     
     public init(multisig pubKeys:[PubKey], threshold: UInt, bip67: Bool = true) {
+        precondition(threshold > 0)
         let pubkeys_bytes_len = Int(EC_PUBLIC_KEY_LEN) * pubKeys.count
         let pubkeys_bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: pubkeys_bytes_len)
         var offset = 0


### PR DESCRIPTION
Preempt a crash in `wally_scriptpubkey_multisig_from_bytes` below. The [constraint](https://github.com/ElementsProject/libwally-core/blob/release_0.7.7/src/script.c#L562) is [not documented upstream](https://wally.readthedocs.io/en/release_0.7.7/script/#c.wally_scriptpubkey_multisig_from_bytes), but it's sane.

I believe consensus rules do allow for 0 signatures by the way: https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L1032-L1053

But's non-standard (and a bad idea):  https://github.com/bitcoin/bitcoin/blob/46fc4d1a24c88e797d6080336e3828e45e39c3fd/src/test/script_standard_tests.cpp#L135-L138