### PR TITLE
Update BIP32.swift to make `privKey` public.

### DIFF
--- a/LibWally/BIP32.swift
+++ b/LibWally/BIP32.swift
@@ -250,7 +250,7 @@ public struct HDKey {
         return PubKey(Data(pub_key), self.network, compressed: true)!
     }
     
-    var privKey: Key? {
+    public var privKey: Key? {
         if self.isNeutered {
            return nil
         }


### PR DESCRIPTION
In order to use individual child keys to sign a PSBT or raw transaction we need to be able to access `privKey`. Considering the `xprv` property is public it does not seem to do any harm to expose a child key. Signing single sig psbt's with anything but the root xprv does not seem to work. I would like to solve that issue but in order to do that I need to be able to access child private keys. Generally speaking it would be nice to access child private keys to sign transactions with irregardless.