### PR TITLE
Bump libwally-core to 0.8.1

### DIFF
--- a/LibWally.xcodeproj/project.pbxproj
+++ b/LibWally.xcodeproj/project.pbxproj
@@ -200,7 +200,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1020;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1230;
 				ORGANIZATIONNAME = Blockchain;
 				TargetAttributes = {
 					FE9CD3B0229C397900345DFA = {
@@ -343,7 +343,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -404,7 +404,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -429,7 +429,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = LibWally/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -465,7 +465,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = LibWally/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/LibWally.xcodeproj/xcshareddata/xcschemes/LibWally.xcscheme
+++ b/LibWally.xcodeproj/xcshareddata/xcschemes/LibWally.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1210"
+   LastUpgradeVersion = "1230"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/LibWally/BIP32.swift
+++ b/LibWally/BIP32.swift
@@ -283,13 +283,13 @@ public struct HDKey {
         }
         hdkey.initialize(to: self.wally_ext_key)
         
-        let fingerprint_bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: Int(FINGERPRINT_LEN))
+        let fingerprint_bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: Int(BIP32_KEY_FINGERPRINT_LEN))
         defer {
             fingerprint_bytes.deallocate()
         }
         
-        precondition(bip32_key_get_fingerprint(hdkey, fingerprint_bytes, Int(FINGERPRINT_LEN)) == WALLY_OK)
-        return Data(bytes: fingerprint_bytes, count: Int(FINGERPRINT_LEN))
+        precondition(bip32_key_get_fingerprint(hdkey, fingerprint_bytes, Int(BIP32_KEY_FINGERPRINT_LEN)) == WALLY_OK)
+        return Data(bytes: fingerprint_bytes, count: Int(BIP32_KEY_FINGERPRINT_LEN))
     }
     
     public func derive (_ path: BIP32Path) throws -> HDKey {

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Opinionated Swift wrapper around [LibWally](https://github.com/ElementsProject/libwally-core),
 a collection of useful primitives for cryptocurrency wallets.
 
-Supports a minimal set of features based on v0.7.7. See also [original docs](https://wally.readthedocs.io/en/release_0.7.7).
+Supports a minimal set of features based on v0.8.1. See also [original docs](https://wally.readthedocs.io/en/release_0.8.1).
 
 - [ ] Core Functions
   - [x] base58 encode / decode


### PR DESCRIPTION
Replaces #33. Builds on top of #44.

The PSBT code for libwally-core was overhauled, which this PR takes into account.

Libwally-core now includes secp256k1 as a submodule, which improves audibility. This may however cause some annoyance when updating (you may need to delete `CLibWally/libwally-core/src/secp256k1` and sync the submodule)