### PR TITLE
Add brew dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ carthage update libwally-swift
 Install dependencies:
 
 ```sh
-brew install gnu-sed
+brew install gnu-sed automake
 ```
 
 Clone the repository, including submodules:


### PR DESCRIPTION
See #47. This packages is used by [upstream](https://github.com/ElementsProject/libwally-core/blob/71c386c2faf3d6c5cff5b5f148f9d4b443269dc2/.github/workflows/wheels.yml#L46) Github CI. The Travis machine apparently already has it.